### PR TITLE
fixes bug in join generic

### DIFF
--- a/R/bind-fmap-join.R
+++ b/R/bind-fmap-join.R
@@ -37,5 +37,5 @@ bind <- function(.m, .f, ...) {
 #' @rdname monad-generics
 #' @export
 join <- function(.m) {
-  UseMethod("bind")
+  UseMethod("join")
 }


### PR DESCRIPTION
This is likely not an active topic, but I found myself twiddling with this and found *it needed fixing* (variant of "someone is wrong on the internet").

FWIW, my motivation is to try to build an experimental monad based on purrr::safely, so that you can check for errors at the end of a monad-pipe, and get an informative error message.

Of course, I have no idea if such a thing would be useful, well-advised, or if I can build it, but none of that will stop me from trying :)